### PR TITLE
Containerize the SFU and publish images to the registry

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,47 @@
+name: Build and publish Docker image
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request: {}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -30,16 +30,16 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
+            type=sha,format=short,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+##
+## Build
+##
+FROM golang:1.19 AS build
+
+WORKDIR /app
+
+COPY go.mod ./
+COPY go.sum ./
+
+# Cache dependencies before building and copying the source code, so that
+# we don't need to re-download when building and so that the change in the
+# source code do not invalidate our downloaded layer.
+RUN go mod download
+
+COPY ./src ./src
+
+RUN go build -o /waterfall ./src
+
+
+##
+## Deploy
+##
+FROM ubuntu:22.04
+
+RUN apt update \
+    && apt install -y --no-install-recommends \
+    dumb-init \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /
+
+COPY --from=build /waterfall /usr/bin/waterfall
+
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["waterfall"]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ In order to build a docker image, run the following in the root directory:
 
 Just use `docker-compose up` and you're good to go.
 
+Or `docker-compose up -d` if you're running it on a server in a detached state.
+
+You can then find your container ID by checking `docker container ls`.
+
+Which could then be used to e.g. check the container logs with `docker container logs <ID>`.
+
+If you're developing locally, you can replace the path to the image with your own image tag, e.g. `matrix/waterfall`.
+
 #### Hard Way
 
 To run the image from the current directory assuming that there is a `config.yaml`:

--- a/README.md
+++ b/README.md
@@ -44,3 +44,19 @@ from the MSC.
 * `./scripts/build.sh`
 * `./dist/bin`
 * Access at <http://localhost:8080>
+
+## Docker
+
+In order to build a docker image, run the following in the root directory:
+
+`$ docker build . -t matrix/materwall`
+
+To run the image from the current directory assuming that there is a `config.yaml`:
+
+```
+$ docker run \
+    -v $(pwd)/config.yaml:/config.yaml \
+    --network host \
+    -it --rm matrix/waterfall \
+    sfu --config config.yaml
+```

--- a/README.md
+++ b/README.md
@@ -47,9 +47,19 @@ from the MSC.
 
 ## Docker
 
+### Building
+
 In order to build a docker image, run the following in the root directory:
 
 `$ docker build . -t matrix/materwall`
+
+### Running
+
+#### Easy Way
+
+Just use `docker-compose up` and you're good to go.
+
+#### Hard Way
 
 To run the image from the current directory assuming that there is a `config.yaml`:
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: "3.3"
+services:
+  waterfall:
+    container_name: waterfall
+    image: matrix/waterfall # TODO: replace with the image of the waterfall (e.g. GitHub container registry)
+    network_mode: host
+    restart: always
+    environment:
+      USER_ID: "@sfu:shadowfax"
+      HOMESERVER_URL: "http://localhost:8008"
+      ACCESS_TOKEN: "..."
+      TIMEOUT: 30

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.3"
 services:
   waterfall:
     container_name: waterfall
-    image: matrix/waterfall # TODO: replace with the image of the waterfall (e.g. GitHub container registry)
+    image: ghcr.io/matrix-org/waterfall:main
     network_mode: host
     restart: always
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,8 @@ services:
     network_mode: host
     restart: always
     environment:
-      USER_ID: "@sfu:shadowfax"
-      HOMESERVER_URL: "http://localhost:8008"
-      ACCESS_TOKEN: "..."
-      TIMEOUT: 30
+      CONFIG: |
+        homeserverurl: "http://localhost:8008"
+        userid: "@sfu:shadowfax"
+        accesstoken: "..."
+        timeout: 30

--- a/src/call.go
+++ b/src/call.go
@@ -513,7 +513,7 @@ func (c *Call) SendDataChannelMessage(msg event.SFUMessage) {
 }
 
 func (c *Call) CheckKeepAliveTimestamp() {
-	timeout := time.Second * time.Duration(config.Timeout)
+	timeout := time.Second * time.Duration(config.KeepAliveTimeout)
 	for range time.Tick(timeout) {
 		if c.lastKeepAliveTimestamp.Add(timeout).Before(time.Now()) {
 			if c.PeerConnection.ConnectionState() != webrtc.PeerConnectionStateClosed {

--- a/src/config.go
+++ b/src/config.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+	"maunium.net/go/mautrix/id"
+)
+
+// The mandatory SFU configuration.
+type Config struct {
+	// The Matrix ID (MXID) of the SFU.
+	UserID id.UserID
+	// The ULR of the homeserver that SFU talks to.
+	HomeserverURL string
+	// The access token for the Matrix SDK.
+	AccessToken string
+	// Keep-alive timeout for WebRTC connections. If no keep-alive has been received
+	// from the client for this duration, the connection is considered dead.
+	KeepAliveTimeout int
+}
+
+// Load config from the provided string.
+// Returns an error if the string is not a valid YAML.
+func loadConfigFromString(configString string) (*Config, error) {
+	logrus.Info("loading config from string")
+
+	var config Config
+	if err := yaml.Unmarshal([]byte(configString), &config); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal YAML file: %w", err)
+	}
+
+	return &config, nil
+}
+
+// ErrNoConfigEnvVar is returned when the CONFIG environment variable is not set.
+var ErrNoConfigEnvVar = errors.New("environment variable not set or invalid")
+
+// Tries to load the config from environment variables.
+// Returns an error if not all environment variables are set.
+func loadConfigFromEnv() (*Config, error) {
+	configEnv := os.Getenv("CONFIG")
+	if configEnv == "" {
+		return nil, ErrNoConfigEnvVar
+	}
+
+	return loadConfigFromString(configEnv)
+}
+
+// Tries to load a config from the provided path.
+func loadConfigFromPath(path string) (*Config, error) {
+	logrus.WithField("path", path).Info("loading config")
+
+	file, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	return loadConfigFromString(string(file))
+}

--- a/src/main.go
+++ b/src/main.go
@@ -116,14 +116,10 @@ func main() {
 	go killListener(c, beforeExit)
 
 	var err error
+	config, err = loadConfig(*configFilePath)
 
-	config, err = loadConfigFromEnv()
 	if err != nil {
-		logrus.WithError(err).Info("failed to load config from environment variables, trying to load from file")
-
-		if config, err = loadConfigFromPath(*configFilePath); err != nil {
-			logrus.WithError(err).Fatal("failed to load config file")
-		}
+		logrus.WithError(err).Fatal("could not load config")
 	}
 
 	InitMatrix()


### PR DESCRIPTION
Now building an image is part of our CI pipeline for `main` and pull requests.

The package is published to the GitHub Container Registry so that we can easily access the image during the deployment pipeline.

Note that the deployment pipeline is missing here which makes the PR not that useful **right now**, but once we start deploying from a CD pipeline, this all starts making a lot of sense and would allow us to deploy as easily as `scp`ing a single `docker-compose.yml` to the server and then executing an Ansible action.

I also updated the way how to pass the parameters to the image (regular environment variable as it's the most common practice that is portable and compatible with k8s).

Resolves https://github.com/matrix-org/waterfall/issues/36.