### PR TITLE
Introduce stricter lints

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,20 +1,32 @@
 linters-settings:
-  lll:
-    line-length: 120
+  nlreturn:
+    block-size: 2
   wsl:
-    allow-cuddle-declarations: true
+    enforce-err-cuddling: true
+  funlen:
+    lines: 100
+    statements: 50
+  gomoddirectives:
+    replace-allow-list:
+      - maunium.net/go/mautrix # currently needed for the PoC to work (custom mautrix)
 
 linters:
   enable-all: true
   disable:
-    - nlreturn
-    - exhaustivestruct
-    - exhaustruct
-    - cyclop
-    - gochecknoglobals
-    - gomoddirectives
-    - exhaustive
-    - funlen
-    - gofumpt
-    - interfacer
-    - godox # We ought to enable this at some point
+    - ifshort # deprecated
+    - nosnakecase # deprecated
+    - interfacer # deprecated
+    - deadcode # deprecated
+    - exhaustivestruct # deprecated
+    - varcheck # deprecated
+    - structcheck # deprecated
+    - maligned # deprecated
+    - scopelint # deprecated
+    - golint # deprecated
+    - rowserrcheck # https://github.com/golangci/golangci-lint/issues/2649
+    - sqlclosecheck # https://github.com/golangci/golangci-lint/issues/2649
+    - wastedassign # https://github.com/golangci/golangci-lint/issues/2649
+    - gomnd # we use status code numbers and for our use case it's not practical
+    - godox # we have TODOs at this stage of the project, enable in future
+    - forbidigo # we use things like fmt.Printf for debugging, enable in future
+  fast: true

--- a/src/call.go
+++ b/src/call.go
@@ -513,7 +513,7 @@ func (c *Call) SendDataChannelMessage(msg event.SFUMessage) {
 }
 
 func (c *Call) CheckKeepAliveTimestamp() {
-	timeout := time.Second * time.Duration(config.KeepAliveTimeout)
+	timeout := time.Second * time.Duration(c.conf.Config.KeepAliveTimeout)
 	for range time.Tick(timeout) {
 		if c.lastKeepAliveTimestamp.Add(timeout).Before(time.Now()) {
 			if c.PeerConnection.ConnectionState() != webrtc.PeerConnectionStateClosed {

--- a/src/conference.go
+++ b/src/conference.go
@@ -25,21 +25,32 @@ import (
 	"maunium.net/go/mautrix/id"
 )
 
-var ErrNoSuchCall = errors.New("no such call")
-var ErrFoundExistingCallWithSameSessionAndDeviceID = errors.New("found existing call with equal DeviceID and SessionID")
+var (
+	ErrNoSuchCall                                  = errors.New("no such call")
+	ErrFoundExistingCallWithSameSessionAndDeviceID = errors.New("found existing call with equal DeviceID and SessionID")
+)
+
+// Configuration for the group conferences (calls).
+type ConferenceConfig struct {
+	// Keep-alive timeout for WebRTC connections. If no keep-alive has been received
+	// from the client for this duration, the connection is considered dead.
+	KeepAliveTimeout int
+}
 
 type Conference struct {
 	ConfID string
-	Calls  map[string]*Call // By callID
+	Calls  map[string]*Call  // By callID
+	Config *ConferenceConfig // TODO: this must be protected by a mutex actually
 
 	mutex    sync.RWMutex
 	logger   *logrus.Entry
 	Metadata *Metadata
 }
 
-func NewConference(confID string) *Conference {
+func NewConference(confID string, config *ConferenceConfig) *Conference {
 	conference := new(Conference)
 
+	conference.Config = config
 	conference.ConfID = confID
 	conference.Calls = make(map[string]*Call)
 	conference.Metadata = NewMetadata(conference)

--- a/src/main.go
+++ b/src/main.go
@@ -27,13 +27,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var config *Config
-
-var logTime = flag.Bool("logTime", false, "whether or not to print time and date in logs")
-var configFilePath = flag.String("config", "config.yaml", "configuration file path")
-var cpuProfile = flag.String("cpuProfile", "", "write CPU profile to `file`")
-var memProfile = flag.String("memProfile", "", "write memory profile to `file`")
-
 func initCPUProfiling(cpuProfile *string) func() {
 	logrus.Info("initializing CPU profiling")
 
@@ -95,6 +88,13 @@ func killListener(c chan os.Signal, beforeExit []func()) {
 }
 
 func main() {
+	var (
+		logTime        = flag.Bool("logTime", false, "whether or not to print time and date in logs")
+		configFilePath = flag.String("config", "config.yaml", "configuration file path")
+		cpuProfile     = flag.String("cpuProfile", "", "write CPU profile to `file`")
+		memProfile     = flag.String("memProfile", "", "write memory profile to `file`")
+	)
+
 	flag.Parse()
 
 	initLogging(logTime)
@@ -115,12 +115,10 @@ func main() {
 
 	go killListener(c, beforeExit)
 
-	var err error
-	config, err = loadConfig(*configFilePath)
-
+	config, err := loadConfig(*configFilePath)
 	if err != nil {
 		logrus.WithError(err).Fatal("could not load config")
 	}
 
-	InitMatrix()
+	InitMatrix(config)
 }

--- a/src/matrix.go
+++ b/src/matrix.go
@@ -25,7 +25,7 @@ import (
 
 const localSessionID = "sfu"
 
-func InitMatrix() {
+func InitMatrix(config *Config) {
 	client, err := mautrix.NewClient(config.HomeserverURL, config.UserID, config.AccessToken)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create client")
@@ -43,7 +43,11 @@ func InitMatrix() {
 	logrus.WithField("device_id", whoami.DeviceID).Info("Identified SFU as DeviceID")
 	client.DeviceID = whoami.DeviceID
 
-	focus := NewFocus(fmt.Sprintf("%s (%s)", config.UserID, client.DeviceID), client)
+	focus := NewFocus(
+		fmt.Sprintf("%s (%s)", config.UserID, client.DeviceID),
+		client,
+		&ConferenceConfig{KeepAliveTimeout: config.KeepAliveTimeout},
+	)
 
 	syncer, ok := client.Syncer.(*mautrix.DefaultSyncer)
 	if !ok {


### PR DESCRIPTION
This relates to https://github.com/matrix-org/waterfall/issues/39

This PR does not really refactor anything, but only deals with the lining (introduces more strict lints, and turns off linters that are officially deprecated). The refactoring will be done on top of that.

Primarily it deals with global variables that had to be removed to satisfy the linter (also, global mutable variables a.k.a. singletones are kind of dangerous things in all languages).

This PR is intended to be merged after https://github.com/matrix-org/waterfall/pull/41