### PR TITLE
CI/docker: Allow buliding images from branches and fix the `Dockerfile`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,8 @@ name: Build
 on:
   pull_request: {}
   push:
-    branches: [main]
+    branches:
+      - "**"
 jobs:
   build:
     name: Build

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,7 +3,7 @@ name: Build and publish Docker image
 on:
   push:
     branches:
-      - "main"
+      - "**"
 
 env:
   REGISTRY: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ FROM ubuntu:22.04
 RUN apt update \
     && apt install -y --no-install-recommends \
     dumb-init \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,10 +2,12 @@ version: "3.3"
 services:
   waterfall:
     container_name: waterfall
-    image: ghcr.io/matrix-org/waterfall:main
+    # Use a proper commit hash for specific deployments.
+    image: ghcr.io/matrix-org/waterfall:sha-b64edee
     network_mode: host
     restart: always
     environment:
+      # Set the `CONFIG` to the configuration you want.
       CONFIG: |
         homeserverurl: "http://localhost:8008"
         userid: "@sfu:shadowfax"


### PR DESCRIPTION
The idea is that we trigger the build/lint job as well as the docker job whenever something is pushed to the branch in `waterfall` (excluding forks). Hopefully this is the right syntax to specify it :)