### PR TITLE
peer: fix crash in the rtcp handling

### DIFF
--- a/pkg/peer/peer.go
+++ b/pkg/peer/peer.go
@@ -135,7 +135,10 @@ func (p *Peer[ID]) WriteRTCP(trackID string, packets []RTCPPacketType) error {
 	// Find the right track.
 	receivers := p.peerConnection.GetReceivers()
 	receiverIndex := slices.IndexFunc(receivers, func(receiver *webrtc.RTPReceiver) bool {
-		return receiver.Track().ID() == trackID
+		if receiver.Track() != nil {
+			return receiver.Track().ID() == trackID
+		}
+		return false
 	})
 	if receiverIndex == -1 {
 		return ErrTrackNotFound

--- a/pkg/peer/peer.go
+++ b/pkg/peer/peer.go
@@ -135,10 +135,7 @@ func (p *Peer[ID]) WriteRTCP(trackID string, packets []RTCPPacketType) error {
 	// Find the right track.
 	receivers := p.peerConnection.GetReceivers()
 	receiverIndex := slices.IndexFunc(receivers, func(receiver *webrtc.RTPReceiver) bool {
-		if receiver.Track() != nil {
-			return receiver.Track().ID() == trackID
-		}
-		return false
+		return receiver.Track() != nil && receiver.Track().ID() == trackID
 	})
 	if receiverIndex == -1 {
 		return ErrTrackNotFound


### PR DESCRIPTION
It turns out that a `receiver` may actually have a `nil` track inside. Not sure when and why but it looks like it happens during the negotiation (maybe when the transceiver exists, but the track does not exist already?).

That's the body of the function:
```go
func (r *RTPReceiver) Track() *TrackRemote {
	r.mu.RLock()
	defer r.mu.RUnlock()

	if len(r.tracks) != 1 { // so this is possible!
		return nil
	}
	return r.tracks[0].track
}
```