### PR TITLE
Fix issues with the heartbeat logic on the server

### DIFF
--- a/pkg/common/heartbeat.go
+++ b/pkg/common/heartbeat.go
@@ -26,7 +26,10 @@ func (h *Heartbeat) Start() chan<- Pong {
 	pong := make(chan Pong, UnboundedChannelSize)
 
 	go func() {
-		for range time.Tick(h.Interval) {
+		ticker := time.NewTicker(h.Interval)
+		defer ticker.Stop()
+
+		for range ticker.C {
 			h.SendPing()
 
 			select {

--- a/pkg/conference/matrix_message_processor.go
+++ b/pkg/conference/matrix_message_processor.go
@@ -61,11 +61,11 @@ func (c *Conference) onNewParticipant(participantID ParticipantID, inviteEvent *
 		heartbeat := common.Heartbeat{
 			Interval: time.Duration(c.config.HeartbeatConfig.Interval) * time.Second,
 			Timeout:  time.Duration(c.config.HeartbeatConfig.Timeout) * time.Second,
-			SendPing: func() {
-				participant.sendDataChannelMessage(event.Event{
+			SendPing: func() bool {
+				return participant.sendDataChannelMessage(event.Event{
 					Type:    event.FocusCallPing,
 					Content: event.Content{},
-				})
+				}) == nil
 			},
 			OnTimeout: func() {
 				messageSink.Send(peer.LeftTheCall{event.CallHangupKeepAliveTimeout})

--- a/pkg/conference/participant.go
+++ b/pkg/conference/participant.go
@@ -1,6 +1,7 @@
 package conference
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/matrix-org/waterfall/pkg/common"
@@ -47,15 +48,16 @@ func (p *Participant) asMatrixRecipient() signaling.MatrixRecipient {
 	}
 }
 
-func (p *Participant) sendDataChannelMessage(toSend event.Event) {
+func (p *Participant) sendDataChannelMessage(toSend event.Event) error {
 	jsonToSend, err := toSend.MarshalJSON()
 	if err != nil {
-		p.logger.Error("Failed to marshal data channel message")
-		return
+		return fmt.Errorf("Failed to marshal data channel message: %w", err)
 	}
 
 	if err := p.peer.SendOverDataChannel(string(jsonToSend)); err != nil {
 		// TODO: We must buffer the message in this case and re-send it once the data channel is recovered!
-		p.logger.Error("Failed to send data channel message")
+		return fmt.Errorf("Failed to send data channel message: %w", err)
 	}
+
+	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -101,8 +101,8 @@ func validateConfig(config Config) error {
 	if config.Conference.HeartbeatConfig.Timeout > 30 {
 		return fmt.Errorf("heartbeat.timeout must be 30s or lower")
 	}
-	if config.Conference.HeartbeatConfig.Interval < 30 {
-		return fmt.Errorf("heartbeat.interval must be 30s or higher")
+	if config.Conference.HeartbeatConfig.Interval > 30 {
+		return fmt.Errorf("heartbeat.interval must be 30s or lower")
 	}
 
 	if config.Conference.HeartbeatConfig.Timeout < 5 {

--- a/pkg/peer/peer.go
+++ b/pkg/peer/peer.go
@@ -2,6 +2,7 @@ package peer
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"sync"
 
@@ -178,17 +179,15 @@ func (p *Peer[ID]) SendOverDataChannel(json string) error {
 	defer p.dataChannelMutex.Unlock()
 
 	if p.dataChannel == nil {
-		p.logger.Error("can't send data over data channel: data channel is not ready")
 		return ErrDataChannelNotAvailable
 	}
 
 	if p.dataChannel.ReadyState() != webrtc.DataChannelStateOpen {
-		p.logger.Error("can't send data over data channel: data channel is not open")
 		return ErrDataChannelNotReady
 	}
 
 	if err := p.dataChannel.SendText(json); err != nil {
-		p.logger.WithError(err).Error("failed to send data over data channel")
+		return fmt.Errorf("failed to send data over data channel: %w", err)
 	}
 
 	return nil

--- a/pkg/peer/webrtc.go
+++ b/pkg/peer/webrtc.go
@@ -128,10 +128,10 @@ func (p *Peer[ID]) onDataChannelReady(dc *webrtc.DataChannel) {
 	}
 
 	p.dataChannel = dc
-	p.logger.WithField("label", dc.Label()).Info("Data channel ready")
+	p.logger.WithField("label", dc.Label()).Debug("Data channel ready")
 
 	dc.OnOpen(func() {
-		p.logger.Info("Data channel opened")
+		p.logger.Debug("Data channel opened")
 		p.sink.Send(DataChannelAvailable{})
 	})
 


### PR DESCRIPTION
Per-commit review is required (one fix - one comment with an explanation).

Summary:
- Fixed memory leak caused by `Ticker()` in the heartbeat.
- Fixed heartbeat not assuming that pings can fail (data channel may be closed for instance).
- Fixed wrong comparison in config validation (that mandated interval being 30+ seconds and not 30- seconds as per MSC).
- Remove confusing (duplicate) logs (and make less relevant ones debug).