### PR TITLE
Use FIR packets that Pion returned to us when forwarding

### DIFF
--- a/pkg/conference/peer_message_processor.go
+++ b/pkg/conference/peer_message_processor.go
@@ -130,6 +130,8 @@ func (c *Conference) processRTCPPackets(msg peer.RTCPReceived) {
 			if published.canSendKeyframeAt.Before(time.Now()) {
 				if err := participant.peer.WriteRTCP(msg.TrackID, msg.Packets); err == nil {
 					published.canSendKeyframeAt = time.Now().Add(sendKeyFrameInterval)
+				} else {
+					c.logger.Errorf("Failed to send RTCP packets: %v", err)
 				}
 			}
 		}

--- a/pkg/peer/messages.go
+++ b/pkg/peer/messages.go
@@ -1,6 +1,7 @@
 package peer
 
 import (
+	"github.com/pion/rtcp"
 	"github.com/pion/webrtc/v3"
 	"maunium.net/go/mautrix/event"
 )
@@ -41,7 +42,12 @@ type DataChannelAvailable struct{}
 
 type RTCPReceived struct {
 	TrackID string
-	Packets []RTCPPacketType
+	Packets []RTCPPacket
+}
+
+type RTCPPacket struct {
+	Type    RTCPPacketType
+	Content rtcp.Packet
 }
 
 type RTCPPacketType int

--- a/pkg/peer/peer.go
+++ b/pkg/peer/peer.go
@@ -152,7 +152,7 @@ func (p *Peer[ID]) WriteRTCP(trackID string, packets []RTCPPacket) error {
 			toSend[i] = &rtcp.PictureLossIndication{MediaSSRC: ssrc}
 		case FullIntraRequest:
 			// FIRs are a bit more complicated. They have a sequence number that must be incremented
-			// and the an additional SSRC inside FIR payload. So we rewrite the media SSRC here.
+			// and an additional SSRC inside FIR payload. So we rewrite the media SSRC here.
 			rewrittenFIR, _ := packet.Content.(*rtcp.FullIntraRequest)
 			rewrittenFIR.MediaSSRC = ssrc
 			// TODO: Check is we also need to rewrite the SSRC inside the FIR payload.


### PR DESCRIPTION
Note: this does not seem to fix anything, though it feels more correct since FIRs have an FIR header.