### PR TITLE
Send `kind` in track metadata

### DIFF
--- a/pkg/common/track_info.go
+++ b/pkg/common/track_info.go
@@ -63,6 +63,7 @@ func (s SimulcastLayer) String() string {
 type TrackInfo struct {
 	TrackID  string
 	StreamID string
+	Kind     webrtc.RTPCodecType
 	Codec    webrtc.RTPCodecCapability
 	Layer    SimulcastLayer
 }
@@ -71,6 +72,7 @@ func TrackInfoFromTrack(track *webrtc.TrackRemote) TrackInfo {
 	return TrackInfo{
 		TrackID:  track.ID(),
 		StreamID: track.StreamID(),
+		Kind:     track.Kind(),
 		Codec:    track.Codec().RTPCodecCapability,
 		Layer:    RIDToSimulcastLayer(track.RID()),
 	}

--- a/pkg/conference/state.go
+++ b/pkg/conference/state.go
@@ -60,12 +60,19 @@ func (c *Conference) getAvailableStreamsFor(forParticipant participant.ID) event
 		// Skip us. As we know about our own tracks.
 		if track.Owner != forParticipant {
 			streamID := track.Info.StreamID
+			kind := track.Info.Kind.String()
 
 			if metadata, ok := streamsMetadata[streamID]; ok {
-				metadata.Tracks[trackID] = event.CallSDPStreamMetadataTrack{}
+				metadata.Tracks[trackID] = event.CallSDPStreamMetadataTrack{
+					Kind: kind,
+				}
 				streamsMetadata[streamID] = metadata
 			} else if metadata, ok := c.streamsMetadata[streamID]; ok {
-				metadata.Tracks = event.CallSDPStreamMetadataTracks{trackID: event.CallSDPStreamMetadataTrack{}}
+				metadata.Tracks = event.CallSDPStreamMetadataTracks{
+					trackID: event.CallSDPStreamMetadataTrack{
+						Kind: kind,
+					},
+				}
 				streamsMetadata[streamID] = metadata
 			} else {
 				c.logger.Warnf("Don't have metadata for %s", trackID)


### PR DESCRIPTION
This should fix the issue where the client doesn't actually request different layers when a feed side changes. The client needs this as it has no other way to find the correct track since track ids can lie.