### PR TITLE
simulcast: properly check the type of a track

### DIFF
--- a/pkg/conference/participant/track.go
+++ b/pkg/conference/participant/track.go
@@ -27,7 +27,7 @@ type PublishedTrack struct {
 func (p *PublishedTrack) GetDesiredLayer(requestedWidth, requestedHeight int) common.SimulcastLayer {
 	// Audio track. For them we don't have any simulcast. We also don't have any simulcast for video
 	// if there was no simulcast enabled at all.
-	if !p.Metadata.IsVideoTrack() || len(p.Layers) == 0 {
+	if p.Info.Kind == webrtc.RTPCodecTypeAudio || len(p.Layers) == 0 {
 		return common.SimulcastLayerNone
 	}
 
@@ -86,8 +86,4 @@ type TrackMetadata struct {
 
 func (t TrackMetadata) FullResolution() int {
 	return t.MaxWidth * t.MaxHeight
-}
-
-func (t TrackMetadata) IsVideoTrack() bool {
-	return t.FullResolution() > 0
 }


### PR DESCRIPTION
A minor thing that I noticed during the testing yesterday, namely that sometimes the SFU subscribed to a video track simulcast layer `SimulcastLayerNone` as if there was no simulcast on a video track (according to log there were 3 layers). I checked when this could happen. And found that only in 2 cases this is the case:

1. There are no published simulcast layers (not the case).
2. If metadata for this track has a width of height equal to 0 (this was a check for audio vs video track).

I replaced the (2) with a more reliable check for the type of media (we actually have always had this information) since it seems to be a better (reliable) way to check if it's a video track or an audio track.

Though we must later investigate if the client can send `0` as `width` or `height` for the video track by mistake.