### PR TITLE
Bug fixes discovered during the demo

### DIFF
--- a/pkg/conference/participant/track.go
+++ b/pkg/conference/participant/track.go
@@ -80,6 +80,5 @@ func calculateDesiredLayer(fullWidth, fullHeight int, desiredWidth, desiredHeigh
 		return common.SimulcastLayerMedium
 	}
 
-	// We can't get here actually.
 	return common.SimulcastLayerLow
 }

--- a/pkg/conference/participant/track.go
+++ b/pkg/conference/participant/track.go
@@ -36,7 +36,12 @@ func (p *PublishedTrack) GetOptimalLayer(requestedWidth, requestedHeight int) co
 
 	// Ideally, here we would need to send an error if the desired layer is not available, but we don't
 	// have a way to do it. So we just return the closest available layer.
-	priority := []common.SimulcastLayer{desiredLayer, common.SimulcastLayerMedium, common.SimulcastLayerLow}
+	priority := []common.SimulcastLayer{
+		desiredLayer,
+		common.SimulcastLayerMedium,
+		common.SimulcastLayerLow,
+		common.SimulcastLayerHigh,
+	}
 
 	// More Go boilerplate.
 	for _, desiredLayer := range priority {

--- a/pkg/conference/participant/track_test.go
+++ b/pkg/conference/participant/track_test.go
@@ -39,6 +39,8 @@ func TestGetOptimalLayer(t *testing.T) {
 		{layers(high, mid, low), 0, 0, 1600, 1000, low},
 		{layers(high, mid, low), 0, 0, 0, 0, low},
 		{layers(high, mid, low), 600, 400, 0, 0, low},
+
+		{layers(high), 1280, 720, 200, 200, high},
 	}
 
 	mock := participant.PublishedTrack{

--- a/pkg/conference/participant/tracker.go
+++ b/pkg/conference/participant/tracker.go
@@ -187,8 +187,8 @@ func (t *Tracker) Subscribe(participantID ID, requests []SubscribeRequest) {
 				request.TrackInfo,
 				request.Simulcast,
 				participant.Peer,
-				func(track common.TrackInfo, simulcast common.SimulcastLayer) {
-					participant.Peer.RequestKeyFrame(track, simulcast)
+				func(track common.TrackInfo, simulcast common.SimulcastLayer) error {
+					return participant.Peer.RequestKeyFrame(track, simulcast)
 				},
 				participant.Logger,
 			)

--- a/pkg/peer/peer.go
+++ b/pkg/peer/peer.go
@@ -172,6 +172,6 @@ func (p *Peer[ID]) ProcessSDPOffer(sdpOffer string) (*webrtc.SessionDescription,
 	return &answer, nil
 }
 
-func (p *Peer[ID]) RequestKeyFrame(info common.TrackInfo, simulcast common.SimulcastLayer) {
-	p.sink.Send(KeyFrameRequestReceived{info, simulcast})
+func (p *Peer[ID]) RequestKeyFrame(info common.TrackInfo, simulcast common.SimulcastLayer) error {
+	return p.sink.TrySend(KeyFrameRequestReceived{info, simulcast})
 }

--- a/pkg/peer/subscription/video.go
+++ b/pkg/peer/subscription/video.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type RequestKeyFrameFn = func(track common.TrackInfo, simulcast common.SimulcastLayer)
+type RequestKeyFrameFn = func(track common.TrackInfo, simulcast common.SimulcastLayer) error
 
 type VideoSubscription struct {
 	rtpSender *webrtc.RTPSender
@@ -142,7 +142,10 @@ func (s *VideoSubscription) readRTCP() {
 }
 
 func (s *VideoSubscription) requestKeyFrame() {
-	s.requestKeyFrameFn(s.info, common.SimulcastLayer(s.currentLayer.Load()))
+	layer := common.SimulcastLayer(s.currentLayer.Load())
+	if err := s.requestKeyFrameFn(s.info, layer); err != nil {
+		s.logger.Errorf("Failed to request key frame: %s", err)
+	}
 }
 
 // Internal state of a worker that runs in its own goroutine.


### PR DESCRIPTION
1. There were cases where EC only published a single quality for some unknown reason, that quality was `high`. The requested quality was closer to `low`, so SFU subscribed to the non-existing `low` layer (bug). This is now fixed. In such cases, where only one quality is available, we'll subscribe to it, even though it's definitely not what the user requested (it's bigger than the requested quality). **FIXME:** we probably don't want to do it really and instead we must inform the client that such a layer does not exist!
2. There was a possibility to hang the conference if the channel gets full when there are too many packets combined with key frame requests. This possibility is now eliminated.