### PR TITLE
peer: add data channel worker

### DIFF
--- a/pkg/peer/datachannel.go
+++ b/pkg/peer/datachannel.go
@@ -1,0 +1,33 @@
+package peer
+
+import (
+	"time"
+
+	"github.com/matrix-org/waterfall/pkg/peer/state"
+	"github.com/matrix-org/waterfall/pkg/worker"
+	"github.com/sirupsen/logrus"
+)
+
+func newDataChannelWorker(state *state.PeerState, logger *logrus.Entry) *worker.Worker[string] {
+	// Create the configuration for the data channel worker.
+	workerConfig := worker.Config[string]{
+		ChannelSize: 32,
+		Timeout:     time.Hour,
+		OnTimeout:   func() {},
+		OnTask: func(json string) {
+			ch := state.GetDataChannel()
+			if ch == nil {
+				logger.Warn("dropping the message, channel not available")
+				return
+			}
+
+			if err := ch.SendText(json); err != nil {
+				logger.WithError(err).Error("failed to send data channel message")
+				return
+			}
+		},
+	}
+
+	// Create the worker.
+	return worker.StartWorker(workerConfig)
+}


### PR DESCRIPTION
This relates to https://github.com/matrix-org/waterfall/issues/133

The effect of this change is not as large as anticipated though. It turns out that for smaller messages in conferences with up to 6 people, the operation of sending to the data channel on the peer level took no more than 20µs on average. The peaks occur from time to time (up to 1 ms), but they are not as large, so the effect of this worker is not really that noticeable.

So now I question if it's worth it at all. Decided to file a PR to at least demonstrate how simple and small the change was and where it was done. We can close if we think that the complexity does not justify the improvement.

Please check the details: https://github.com/matrix-org/waterfall/issues/133#issuecomment-1441729488