### PR TITLE
rewriter: add vp8 keyframe detection function

### DIFF
--- a/pkg/conference/subscription/rewriter/vp8.go
+++ b/pkg/conference/subscription/rewriter/vp8.go
@@ -1,0 +1,29 @@
+package rewriter
+
+import (
+	"github.com/pion/rtp"
+	"github.com/pion/rtp/codecs"
+)
+
+// Determines if a given packet contains a VP8 keyframe.
+func IsVP8Keyframe(packet rtp.Packet) bool {
+	// First try to parse the packet as a VP8 packet.
+	vp8Packet := codecs.VP8Packet{}
+
+	payload, err := vp8Packet.Unmarshal(packet.Payload)
+	if err != nil {
+		return false
+	}
+
+	// At this point we know that we're dealing with a VP8 packet
+	// and we have a so-called "VP8 Payload Descriptor" that Pion
+	// parses into the `vp8Packet` structure. This is not to be
+	// confused with the "VP8 Payload Header", one bit of which
+	// we're parsing here. The P bit is set to 0 for the key frames.
+	Pbit := (payload[0] & 0x01)
+
+	// We also must check that the S bit from the VP8 Payload Descriptor
+	// is set to 1 as S denotes a start of a new VP8 partition. Typically
+	// key frames have it set to 1.
+	return vp8Packet.S == 1 && Pbit == 0
+}


### PR DESCRIPTION
We've postponed working on https://github.com/matrix-org/waterfall/issues/100

The branch I started more than a month ago is obsolete and does not compile anymore (due to conflicts caused by changes done in the previous PRs). Still, the function for the detection of VP8 frames is somewhat isolated and does not really have any dependencies, so I decided to file the PR with this small function so that I can remove the now obsolete branch while preserving something that could be reused by one who works on the issue in the future.