### PR TITLE
subscription: don't assume muted tracks stalled

### DIFF
--- a/pkg/conference/participant/tracker.go
+++ b/pkg/conference/participant/tracker.go
@@ -161,7 +161,11 @@ func (t *Tracker) RemovePublishedTrack(id track.TrackID) {
 }
 
 // Subscribes a given participant to the track.
-func (t *Tracker) Subscribe(participantID ID, trackID track.TrackID, requirements track.TrackMetadata) error {
+func (t *Tracker) Subscribe(
+	participantID ID,
+	trackID track.TrackID,
+	desiredWidth, desiredHeight int,
+) error {
 	// Check if the participant exists that wants to subscribe exists.
 	participant := t.participants[participantID]
 	if participant == nil {
@@ -175,7 +179,13 @@ func (t *Tracker) Subscribe(participantID ID, trackID track.TrackID, requirement
 	}
 
 	// Subscribe to the track.
-	if err := published.Subscribe(participantID, participant.Peer, requirements, participant.Logger); err != nil {
+	if err := published.Subscribe(
+		participantID,
+		participant.Peer,
+		desiredWidth,
+		desiredHeight,
+		participant.Logger,
+	); err != nil {
 		return err
 	}
 

--- a/pkg/conference/peer_message_processing.go
+++ b/pkg/conference/peer_message_processing.go
@@ -172,8 +172,7 @@ func (c *Conference) processTrackSubscriptionMessage(
 
 	// Now let's handle the subscribe commands.
 	for _, track := range msg.Subscribe {
-		requirements := published.TrackMetadata{track.Width, track.Height}
-		if err := c.tracker.Subscribe(p.ID, track.TrackID, requirements); err != nil {
+		if err := c.tracker.Subscribe(p.ID, track.TrackID, track.Width, track.Height); err != nil {
 			p.Logger.Errorf("Failed to subscribe to track %s: %v", track.TrackID, err)
 			continue
 		}

--- a/pkg/conference/state.go
+++ b/pkg/conference/state.go
@@ -122,9 +122,19 @@ func streamIntoTrackMetadata(
 	tracksMetadata := make(map[published.TrackID]published.TrackMetadata)
 	for _, metadata := range streamMetadata {
 		for id, track := range metadata.Tracks {
+			// Determine if a given track is muted.
+			var muted bool
+			switch track.Kind {
+			case "audio":
+				muted = metadata.AudioMuted
+			case "video":
+				muted = metadata.VideoMuted
+			}
+
 			tracksMetadata[id] = published.TrackMetadata{
 				MaxWidth:  track.Width,
 				MaxHeight: track.Height,
+				Muted:     muted,
 			}
 		}
 	}

--- a/pkg/conference/subscription/audio.go
+++ b/pkg/conference/subscription/audio.go
@@ -49,6 +49,10 @@ func (s *AudioSubscription) Simulcast() webrtc_ext.SimulcastLayer {
 	return webrtc_ext.SimulcastLayerNone
 }
 
+func (s *AudioSubscription) UpdateMuteState(muted bool) {
+	// We don't have any business logic at the moment for audio subscriptions.
+}
+
 func (s *AudioSubscription) readRTCP() {
 	// Read incoming RTCP packets. Before these packets are returned they are processed by interceptors.
 	// For things like NACK this needs to be called.

--- a/pkg/conference/subscription/subscription.go
+++ b/pkg/conference/subscription/subscription.go
@@ -11,6 +11,7 @@ type Subscription interface {
 	WriteRTP(packet rtp.Packet) error
 	SwitchLayer(simulcast webrtc_ext.SimulcastLayer)
 	Simulcast() webrtc_ext.SimulcastLayer
+	UpdateMuteState(muted bool)
 }
 
 type SubscriptionController interface {

--- a/pkg/conference/track/simulcast.go
+++ b/pkg/conference/track/simulcast.go
@@ -8,6 +8,7 @@ import (
 // This metadata is only set for video tracks at the moment.
 type TrackMetadata struct {
 	MaxWidth, MaxHeight int
+	Muted               bool
 }
 
 // Calculate the layer that we can use based on the requirements passed as parameters and available layers.

--- a/pkg/conference/track/track.go
+++ b/pkg/conference/track/track.go
@@ -257,7 +257,7 @@ func (p *PublishedTrack[SubscriberID]) Subscribe(
 		p.video.publishers[layer].AddSubscription(sub)
 	}
 
-	p.logger.Info("New subscriber:", subscriberID)
+	p.logger.WithField("subscriber", subscriberID).WithField("layer", layer).Info("New subscription")
 
 	return nil
 }


### PR DESCRIPTION
When the user mutes the video, we don't get any RTPs. We don't assume this error anymore and don't change the status of the track and its telemetry for that.

This removes false positives related to the
https://github.com/matrix-org/waterfall/issues/121