### PR TITLE
matrix: generalise signaling functions

### DIFF
--- a/pkg/conference/matrix_worker.go
+++ b/pkg/conference/matrix_worker.go
@@ -19,7 +19,11 @@ func newMatrixWorker(handler signaling.MatrixSignaler) *matrixWorker {
 		ChannelSize: 128,
 		Timeout:     time.Hour,
 		OnTimeout:   func() {},
-		OnTask:      func(msg signaling.MatrixMessage) { handler.SendMessage(msg) },
+		OnTask: func(msg signaling.MatrixMessage) {
+			if err := handler.SendMessage(msg); err != nil {
+				logrus.Errorf("Failed to send matrix message: %v", err)
+			}
+		},
 	}
 
 	matrixWorker := &matrixWorker{


### PR DESCRIPTION
Required for https://github.com/vector-im/voip-internal/issues/137 since our LiveKit implementation uses `waterfall/pkg` as a dependency (imports certain generic parts like signaling since they are going to be the same). That spares the copy-paste in the LiveKit integration.